### PR TITLE
Update weather endpoint to OpenWeatherMap v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd home-dashboard
 
 # 3 · Configure (click the ⚙ gear icon)
 #    • Location (or enable “Use browser location”)
-#    • OpenWeatherMap API key
+#    • OpenWeatherMap API key (v3)
 #    • Optional iCal URLs for calendars
 #    • Optional Todoist token for the shopping-list widget
 #    • Dark-mode hours & refresh intervals
@@ -29,7 +29,7 @@ Settings are saved to `localStorage`, so they persist across reloads.
 
 ## Features
 
-- Live current weather & “feels like” temperature (OpenWeatherMap)
+- Live current weather & “feels like” temperature (OpenWeatherMap API v3)
 - Five-day hourly forecast
 - Multiple calendar feeds (iCal links or Google Calendar)
 - Shopping list pulled from **Todoist**

--- a/index.html
+++ b/index.html
@@ -1580,7 +1580,7 @@ async function fetchAndDisplayWeather() {
   try {
     const { lat, lon } = await resolveLatLon();
     const oneCallUrl =
-      `https://api.openweathermap.org/data/2.5/onecall` +
+      `https://api.openweathermap.org/data/3.0/onecall` +
       `?lat=${lat}&lon=${lon}` +
       `&units=${settings.weather.units}` +
       `&exclude=minutely,alerts` +


### PR DESCRIPTION
## Summary
- switch weather API requests to `data/3.0/onecall`
- document using OpenWeatherMap API v3 in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d8811c12883238381f4a08863d358