### PR TITLE
Align hourly forecast inside first day box

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,8 @@
             display: flex;
             justify-content: space-between;
             padding: 20px;
-            margin-top: auto;
+            margin-top: 20px;
+            width: 100%;
         }
         
         .hour-forecast {
@@ -763,6 +764,56 @@
                         <span class="event-title cal-0">Golf lesson</span>
                     </div>
                 </div>
+                <div class="hourly-forecast">
+                    <div class="hour-forecast">
+                        <div class="hour-label">9am</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">45°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">10am</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">47°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">11am</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">48°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">12pm</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">50°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">1pm</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">51°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">2pm</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">52°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">3pm</div>
+                        <div class="hour-icon"><i class="fas fa-cloud-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">53°</div>
+                    </div>
+                    <div class="hour-forecast">
+                        <div class="hour-label">4pm</div>
+                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
+                        <div class="hour-precipitation">0%</div>
+                        <div class="hour-temp">54°</div>
+                    </div>
+                </div>
             </div>
 
             <div class="day-forecast">
@@ -804,57 +855,6 @@
         <div class="shopping-list">
             <div class="shopping-title">Shopping</div>
             <div id="shopping-items"></div>
-        </div>
-    </div>
-
-    <div class="hourly-forecast">
-        <div class="hour-forecast">
-            <div class="hour-label">9am</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">45°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">10am</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">47°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">11am</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">48°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">12pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">50°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">1pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">51°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">2pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">52°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">3pm</div>
-            <div class="hour-icon"><i class="fas fa-cloud-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">53°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">4pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">54°</div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- nest the hourly forecast section inside the first day-forecast element
- adjust `.hourly-forecast` styling for spacing and width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ddf7ab75483239ec0f4d927bfe54d