### PR TITLE
Align hourly forecast below first day box

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,8 @@
             justify-content: space-between;
             padding: 20px;
             margin-top: auto;
+            width: calc(33.333% - 10px);
+            margin-left: 5px;
         }
         
         .hour-forecast {
@@ -857,7 +859,6 @@
             <div class="hour-temp">54°</div>
         </div>
     </div>
-
     <script>
 /* ------------------- Existing Code -------------------- */
 


### PR DESCRIPTION
## Summary
- revert hourly forecast location below middle-section
- size it to match the first day box

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ddf7ab75483239ec0f4d927bfe54d