### PR TITLE
Add calendar URL variable to env example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Example environment configuration for Home Dashboard
+# Copy this file to `.env` and provide your own values.
+
+# OpenWeatherMap API key used for weather data
+WEATHER_API_KEY=
+
+# Todoist API token for the shopping list widget (optional)
+TODOIST_API_TOKEN=
+
+# Optional Google Calendar URLs
+CALENDAR_URL_1=
+# CALENDAR_URL_2=
+# CALENDAR_URL_3=
+# CALENDAR_URL_4=
+# CALENDAR_URL_5=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore user-specific environment files
+.env
+
+# Node modules or other ephemeral directories can be added here

--- a/README.md
+++ b/README.md
@@ -21,17 +21,34 @@ cd home-dashboard
 # 3 · Configure (click the ⚙ gear icon)
 #    • Location (or enable “Use browser location”)
 #    • OpenWeatherMap API key (v3)
-#    • Optional iCal URLs for calendars
+#    • Optional Google Calendar URLs for calendars
 #    • Optional Todoist token for the shopping-list widget
 #    • Dark-mode hours & refresh intervals
 ```
 Settings are saved to `localStorage`, so they persist across reloads.
 
+## Environment Setup
+
+Copy `.env.example` to `.env` and fill in your own values.  The dashboard
+currently recognises these variables:
+
+- `WEATHER_API_KEY` – your OpenWeatherMap API key
+- `TODOIST_API_TOKEN` – Todoist token for the shopping list widget (optional)
+- `CALENDAR_URL_1` – URL of your first Google Calendar (or any iCal feed)
+
+```bash
+cp .env.example .env
+# Edit .env and add your secrets
+```
+
+Specify additional calendars by uncommenting `CALENDAR_URL_2` up to
+`CALENDAR_URL_5` in your `.env` file.
+
 ## Features
 
 - Live current weather & “feels like” temperature (OpenWeatherMap API v3)
 - Five-day hourly forecast
-- Multiple calendar feeds (iCal links or Google Calendar)
+- Multiple calendar feeds (Google Calendar or iCal links)
 - Shopping list pulled from **Todoist**
 - Dark-mode schedule & kiosk-mode toggle
 - Entirely client-side – drop it on any static host


### PR DESCRIPTION
## Summary
- expose `CALENDAR_URL_1` in `.env.example` and keep four placeholders
- document the calendar URL variable and extra placeholders in README
- update references to iCal calendar URLs to Google Calendars

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686de045faa083238a4dfb05cd6bdd30