### PR TITLE
Remove duplicate hourly forecast

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
             justify-content: space-between;
             padding: 20px;
             margin-top: auto;
-            width: calc(33.333% - 10px);
+            width: calc(20% - 10px);
             margin-left: 5px;
         }
         
@@ -770,56 +770,6 @@
                     <div class="day-event">
                         <span class="event-time">1:30 PM</span>
                         <span class="event-title cal-0">Golf lesson</span>
-                    </div>
-                </div>
-                <div class="hourly-forecast">
-                    <div class="hour-forecast">
-                        <div class="hour-label">9am</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">45°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">10am</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">47°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">11am</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">48°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">12pm</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">50°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">1pm</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">51°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">2pm</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">52°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">3pm</div>
-                        <div class="hour-icon"><i class="fas fa-cloud-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">53°</div>
-                    </div>
-                    <div class="hour-forecast">
-                        <div class="hour-label">4pm</div>
-                        <div class="hour-icon"><i class="fas fa-sun"></i></div>
-                        <div class="hour-precipitation">0%</div>
-                        <div class="hour-temp">54°</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- drop the first hourly forecast example block
- keep the bottom hourly forecast section and bound its width to match a single day column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686de3db4b508323aed19ca1b6a6ce9e