### PR TITLE
Fix seconds baseline alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,6 @@
 
         .time-display sup {
             font-size: 1.6rem;
-            position: relative;
-            top: -0.35em; /* align top of digits with minutes */
             vertical-align: baseline;
         }
         
@@ -497,13 +495,7 @@
 
             .time-display sup {
                 font-size: 2.3rem;
-                position: relative;
-                top: -0.45em; /* align top of digits with minutes */
                 vertical-align: baseline;
-            }
-            
-            .time-display sup {
-                font-size: 2.3rem;
             }
 
             .date-display {


### PR DESCRIPTION
## Summary
- align seconds text baseline with minutes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687268da33508323a388bdb0518b5ccf