### PR TITLE
Limit hourly forecast to five slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
             justify-content: space-between;
             padding: 20px;
             margin-top: auto;
-            width: calc(20% - 10px);
+            width: 100%;
             margin-left: 5px;
         }
         
@@ -846,24 +846,6 @@
             <div class="hour-icon"><i class="fas fa-sun"></i></div>
             <div class="hour-precipitation">0%</div>
             <div class="hour-temp">51°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">2pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">52°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">3pm</div>
-            <div class="hour-icon"><i class="fas fa-cloud-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">53°</div>
-        </div>
-        <div class="hour-forecast">
-            <div class="hour-label">4pm</div>
-            <div class="hour-icon"><i class="fas fa-sun"></i></div>
-            <div class="hour-precipitation">0%</div>
-            <div class="hour-temp">54°</div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove extra hourly forecast slots to show only five
- ensure the hourly forecast container uses full width

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_687269050f80832392f679c9bc340b03